### PR TITLE
chore: support different AWS partitions

### DIFF
--- a/iam-role-vmimport.tf
+++ b/iam-role-vmimport.tf
@@ -35,11 +35,11 @@ resource "aws_iam_policy" "vmimport" {
          "Action":[
             "s3:GetBucketLocation",
             "s3:GetObject",
-            "s3:ListBucket" 
+            "s3:ListBucket"
          ],
          "Resource":[
-            "arn:aws:s3:::${var.image_bucket_name}",
-            "arn:aws:s3:::${var.image_bucket_name}/*"
+            "arn:${var.partition}:s3:::${var.image_bucket_name}",
+            "arn:${var.partition}:s3:::${var.image_bucket_name}/*"
          ]
       },
       {

--- a/inputs.tf
+++ b/inputs.tf
@@ -15,3 +15,9 @@ variable "input_tags" {
   default     = {}
 }
 
+
+variable "partition" {
+  description = "AWS partition (cf. https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html)"
+  type        = string
+  default     = "aws"
+}


### PR DESCRIPTION
## Description

AWS supports different [partitions](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html). Unfortunately, the `bucket_name` variable in insufficient to completely describe the bucket ARN considering this. So, this PR introduces a new variable, `partition`, which users can use to override the default value of `aws`.

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
